### PR TITLE
Add DFS generator and flat-top visualizer

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,9 @@
     <h1>Fixation Formula Finder</h1>
 
     <div id="controls">
-        <button id="runTest">Run Validation & Visualization</button>
+        <button id="runTest">Run Generation</button>
+        <button id="prevVis">Prev</button>
+        <button id="nextVis">Next</button>
     </div>
 
     <pre id="output"></pre>

--- a/script.js
+++ b/script.js
@@ -1,28 +1,86 @@
-document.getElementById("runTest").onclick = () => {
-  // Minimal sample configuration that matches the structure expected by the
-  // validator and visualiser. Each tile has an id, axial coordinates (q,r), the
-  // number of pips (valency) and explicit two way connection definitions.
-  // This simple chain of two tiles is enough to exercise the validation logic
-  // and render something on the canvas.
-  const testConfig = [
-    {
-      id: 1,
-      q: 0,
-      r: 0,
-      pips: 1,
-      connections: [{ targetId: 2 }]
-    },
-    {
-      id: 2,
-      q: 0,
-      r: 1,
-      pips: 1,
-      connections: [{ targetId: 1 }]
+const neighborDirs = [
+  { q: 1, r: 0 },
+  { q: 0, r: 1 },
+  { q: -1, r: 1 },
+  { q: -1, r: 0 },
+  { q: 0, r: -1 },
+  { q: 1, r: -1 }
+];
+
+let knownFormulas = [];
+let generated = [];
+let currentIndex = 0;
+
+async function loadKnownFormulas() {
+  const res = await fetch('data/knownFormulas.json');
+  knownFormulas = await res.json();
+}
+
+function labelKnown(result) {
+  const match = knownFormulas.find(f =>
+    f.valenceCode === result.pipDistribution &&
+    f.shapeType === result.shapeType
+  );
+  if (match) result.name = match.name;
+}
+
+function generateFormulas(valenceArray) {
+  if (valenceArray.length === 0) return [];
+  const results = [];
+  const startTile = { id: 1, q: 0, r: 0, pips: valenceArray[0], connections: [] };
+  recurse([startTile], new Set(['0,0']), valenceArray.slice(1), results);
+  return results;
+}
+
+function recurse(current, occupied, remaining, results) {
+  if (remaining.length === 0) {
+    results.push(JSON.parse(JSON.stringify(current)));
+    return;
+  }
+  const nextPip = remaining[0];
+  const rest = remaining.slice(1);
+  const nextId = current.length + 1;
+  for (const tile of current) {
+    for (const dir of neighborDirs) {
+      const nq = tile.q + dir.q;
+      const nr = tile.r + dir.r;
+      const key = `${nq},${nr}`;
+      if (occupied.has(key)) continue;
+      const newTile = { id: nextId, q: nq, r: nr, pips: nextPip, connections: [{ targetId: tile.id }] };
+      tile.connections.push({ targetId: nextId });
+      current.push(newTile);
+      occupied.add(key);
+      recurse(current, occupied, rest, results);
+      current.pop();
+      occupied.delete(key);
+      tile.connections.pop();
     }
-  ];
+  }
+}
 
-  const result = validateFormula(testConfig);
-  document.getElementById("output").textContent = JSON.stringify(result, null, 2);
+function showCurrent() {
+  if (!generated.length) return;
+  const item = generated[currentIndex];
+  document.getElementById('output').textContent = JSON.stringify(item.result, null, 2);
+  drawFormula(item.config);
+}
 
-  drawFormula(testConfig);
+document.getElementById('runTest').onclick = async () => {
+  await loadKnownFormulas();
+  const configs = generateFormulas([1, 1]);
+  generated = configs.map(cfg => ({ config: cfg, result: (() => { const r = validateFormula(cfg); labelKnown(r); return r; })() }));
+  currentIndex = 0;
+  showCurrent();
+};
+
+document.getElementById('prevVis').onclick = () => {
+  if (!generated.length) return;
+  currentIndex = (currentIndex - 1 + generated.length) % generated.length;
+  showCurrent();
+};
+
+document.getElementById('nextVis').onclick = () => {
+  if (!generated.length) return;
+  currentIndex = (currentIndex + 1) % generated.length;
+  showCurrent();
 };

--- a/visualizer.js
+++ b/visualizer.js
@@ -1,88 +1,64 @@
 const canvas = document.getElementById('visualization');
 const ctx = canvas.getContext('2d');
-const hexRadius = 30; // Matches your initial
-const hexWidth = Math.sqrt(3) * hexRadius;
-const hexHeight = 2 * hexRadius;
+const hexRadius = 30;
 
-// Adjust offsets to center the drawing more effectively
 const centerX = canvas.width / 2;
 const centerY = canvas.height / 2;
 
-// Converts axial coordinates (q, r) to pixel coordinates (x, y)
-// This is using the "pointy top" hex orientation for standard calculation (q = x-axis, r = diagonal)
-// Your validator uses a "flat top" like orientation (q = horiz, r = diag).
-// Let's adjust hexToPixel to match common flat-top derivation if q is horizontal, r is diagonal.
-// If q is horizontal, r is diagonal:
-// x = hexWidth * (q + r / 2)
-// y = hexHeight * (3/4) * r
-// This is consistent with what you had.
 function hexToPixel(q, r) {
-    // For flat-top hexes (which your q,r often implies if q is horizontal axis):
-    const x = hexRadius * (3/2 * q);
-    const y = hexRadius * (Math.sqrt(3)/2 * q + Math.sqrt(3) * r);
-    return {x: centerX + x, y: centerY + y};
+  const x = hexRadius * 1.5 * q;
+  const y = hexRadius * Math.sqrt(3) * (r + q / 2);
+  return { x: centerX + x, y: centerY + y };
 }
 
-// Draws a single hexagon
-function drawHex(x, y, label, color = "#ccc") {
-    ctx.beginPath();
-    for (let i = 0; i < 6; i++) {
-        const angle = Math.PI / 3 * i + Math.PI / 6; // Add PI/6 for flat-top orientation
-        const px = x + hexRadius * Math.cos(angle);
-        const py = y + hexRadius * Math.sin(angle);
-        if (i === 0) ctx.moveTo(px, py);
-        else ctx.lineTo(px, py);
-    }
-    ctx.closePath();
-    ctx.strokeStyle = "#333"; // Hex border
-    ctx.fillStyle = color; // Hex fill
-    ctx.fill();
-    ctx.stroke();
+function drawHex(x, y, label, color = '#ccc') {
+  ctx.beginPath();
+  for (let i = 0; i < 6; i++) {
+    const angle = Math.PI / 3 * i; // flat-top orientation
+    const px = x + hexRadius * Math.cos(angle);
+    const py = y + hexRadius * Math.sin(angle);
+    if (i === 0) ctx.moveTo(px, py);
+    else ctx.lineTo(px, py);
+  }
+  ctx.closePath();
+  ctx.strokeStyle = '#333';
+  ctx.fillStyle = color;
+  ctx.fill();
+  ctx.stroke();
 
-    // Draw label (pip count)
-    ctx.fillStyle = "#000";
-    ctx.font = "14px Arial";
-    ctx.textAlign = "center";
-    ctx.textBaseline = "middle";
-    ctx.fillText(label, x, y);
+  ctx.fillStyle = '#000';
+  ctx.font = '14px Arial';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.fillText(label, x, y);
 }
 
-// Draws a line representing a bond between two tiles
-function drawBond(tile1Px, tile1Py, tile2Px, tile2Py) {
-    ctx.beginPath();
-    ctx.moveTo(tile1Px, tile1Py);
-    ctx.lineTo(tile2Px, tile2Py);
-    ctx.strokeStyle = "red"; // Bond color
-    ctx.lineWidth = 3;
-    ctx.stroke();
+function drawBond(x1, y1, x2, y2) {
+  ctx.beginPath();
+  ctx.moveTo(x1, y1);
+  ctx.lineTo(x2, y2);
+  ctx.strokeStyle = 'red';
+  ctx.lineWidth = 3;
+  ctx.stroke();
 }
 
-// Main function to draw a formula configuration
 function drawFormula(tiles) {
-    ctx.clearRect(0, 0, canvas.width, canvas.height); // Clear previous drawing
-
-    // Store pixel positions for drawing bonds
-    const pixelPositions = new Map();
-
-    // First pass: Draw all hexes and store their pixel positions
-    tiles.forEach(tile => {
-        const {x, y} = hexToPixel(tile.q, tile.r);
-        pixelPositions.set(tile.id, {x, y});
-        drawHex(x, y, tile.pips.toString()); // Display pip count
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  const pixelPositions = new Map();
+  tiles.forEach(tile => {
+    const { x, y } = hexToPixel(tile.q, tile.r);
+    pixelPositions.set(tile.id, { x, y });
+    drawHex(x, y, tile.pips.toString());
+  });
+  tiles.forEach(tile => {
+    const { x: t1x, y: t1y } = pixelPositions.get(tile.id);
+    tile.connections.forEach(conn => {
+      if (tile.id < conn.targetId) {
+        const { x: t2x, y: t2y } = pixelPositions.get(conn.targetId);
+        drawBond(t1x, t1y, t2x, t2y);
+      }
     });
-
-    // Second pass: Draw all connections (bonds)
-    tiles.forEach(tile => {
-        const {x: t1x, y: t1y} = pixelPositions.get(tile.id);
-        tile.connections.forEach(conn => {
-            // Only draw bond once per pair (e.g., if A-B is drawn, don't draw B-A)
-            if (tile.id < conn.targetId) { // Ensures each bond drawn only once
-                const {x: t2x, y: t2y} = pixelPositions.get(conn.targetId);
-                drawBond(t1x, t1y, t2x, t2y);
-            }
-        });
-    });
+  });
 }
 
-// Expose drawFormula to the global scope for script.js
 window.drawFormula = drawFormula;


### PR DESCRIPTION
## Summary
- support flat top orientation hexes in visualizer.js
- implement a very small DFS generator in script.js
- fetch known formulas and show results with navigation
- update index controls for prev/next

## Testing
- `node --check script.js`
- `node --check visualizer.js`

------
https://chatgpt.com/codex/tasks/task_e_68753f884074833297a11dd89b6b1904