### PR TITLE
Fix missing helper functions

### DIFF
--- a/script.js
+++ b/script.js
@@ -196,6 +196,26 @@ function tryAllPossibleBonds(config) {
     return workingConfig;
 }
 
+// Calculates all empty neighbor coordinates around the current configuration.
+// This is used to determine where a new tile could potentially be placed.
+function calculateViablePlacementSpots(config, selectedTilePips) {
+    const occupied = new Set(config.map(t => `${t.q},${t.r}`));
+    const spots = [];
+
+    for (const tile of config) {
+        for (const dir of neighborDirs) {
+            const q = tile.q + dir.q;
+            const r = tile.r + dir.r;
+            const key = `${q},${r}`;
+            if (!occupied.has(key) && !spots.some(s => s.q === q && s.r === r)) {
+                spots.push({ q, r });
+            }
+        }
+    }
+
+    return spots;
+}
+
 
 function showCurrentGeneratedFormula() {
     if (!generatedFormulas.length) {

--- a/validator.js
+++ b/validator.js
@@ -497,9 +497,18 @@ function validateFormula(config) {
   return result;
 }
 
+// Logs the summary of unique and derivative shapes found during validation.
+function printSummary() {
+  console.log('Shape Summary:');
+  for (const [shape, counts] of Object.entries(summary)) {
+    console.log(`${shape} - unique: ${counts.unique}, derivative: ${counts.derivative}`);
+  }
+}
+
 // Expose functions to the global scope for use in script.js (if not using modules)
 // For cleaner separation, in a real app, you'd use ES6 modules.
 // For CodePen/simple file structure, this makes them accessible.
 window.validateFormula = validateFormula;
 window.getCanonicalForm = getCanonicalForm; // For debugging/display if needed
 window.summary = summary; // For accessing the summary outside
+window.printSummary = printSummary;


### PR DESCRIPTION
## Summary
- add missing `calculateViablePlacementSpots` helper
- implement `printSummary` in the validator
- expose the new helper on `window`

## Testing
- `node -c script.js`
- `node -c validator.js`
- `node -c visualizer.js`


------
https://chatgpt.com/codex/tasks/task_e_687545be9018833296ab826f97824b2a