### PR TITLE
Fix canonicalization and visuals, add docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Node dependencies
+node_modules/
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Misc
+*.log

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Fixation Formula Finder
+
+This project visualizes and validates tile-based formulas built on a hexagonal grid. Open `index.html` in a modern browser to try it out. The main JavaScript logic lives in `validator.js`, while `visualizer.js` handles drawing the board.
+
+## Usage
+1. Clone or download this repository.
+2. Open `index.html` in your browser.
+3. Interact with the page to generate and view formulas.
+
+The project currently does not use a build process or external dependencies.
+
+## License
+No explicit license is provided.

--- a/visualizer.js
+++ b/visualizer.js
@@ -1,17 +1,20 @@
 const canvas = document.getElementById('visualization');
 const ctx = canvas.getContext('2d');
-const hexRadius = 30;
+const hexRadius = 30; // Consistent with your current Finder repo's visualizer.js
 
-const hexWidth = Math.sqrt(3) * hexRadius;
-const hexHeight = 2 * hexRadius;
+// Use these defined variables for hex dimensions
+const hexWidth = hexRadius * Math.sqrt(3); // flat-top hex width
+const hexHeight = hexRadius * 2;           // flat-top hex height (point-to-point)
 
 const centerX = canvas.width / 2;
 const centerY = canvas.height / 2;
 
+// Hex to Pixel conversion for FLAT-TOP orientation
+// q-axis is horizontal, r-axis is diagonal (up-right)
 function hexToPixel(q, r) {
-    const x = hexRadius * Math.sqrt(3) * (q + r/2);
-    const y = hexRadius * 1.5 * r;
-    return { x: centerX + x, y: centerY + y };
+  const x = hexWidth * (q + r/2); // Use hexWidth here
+  const y = hexHeight * (3/4) * r; // Use hexHeight here
+  return { x: centerX + x, y: centerY + y };
 }
 function drawHex(x, y, label, color = '#ccc') {
     ctx.beginPath();


### PR DESCRIPTION
## Summary
- overhaul `getCanonicalForm` in `validator.js`
- update `visualizer.js` hex dimension logic
- document basic usage in README
- add `.gitignore`

## Testing
- `node -c validator.js`

------
https://chatgpt.com/codex/tasks/task_e_68755b8d52388332b5fcdfb24753332e