### PR TITLE
Fix missing global tracking set for formulas

### DIFF
--- a/script.js
+++ b/script.js
@@ -22,6 +22,8 @@ const classificationMessage = document.getElementById('classificationMessage');
 const classifyUniqueBtn = document.getElementById('classifyUnique');
 const classifyDerivativeBtn = document.getElementById('classifyDerivative');
 const classifyEchoBtn = document.getElementById('classifyEcho');
+// Ensure global set exists to track seen canonical forms across sessions
+window.globalSeenConfigs = window.globalSeenConfigs || new Set();
 
 
 // --- Constants from game logic (re-declared here for self-containment of script.js) ---


### PR DESCRIPTION
## Summary
- initialize `window.globalSeenConfigs` before use

## Testing
- `pnpm install` *(fails: no package.json)*
- `pnpm lint` *(fails: no package.json)*
- `pnpm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687572344da48332a6c16be1bcf24052