### PR TITLE
Add chirality-aware canonicalisation & logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ Automatic Saving/Loading: All formulas you classify are automatically saved to y
 
 Seed Data: Initially loads a set of "Known" formulas from data/knownFormulas.json as a starting point if your local catalog is empty.
 
+
 Global Uniqueness Tracking: Uses a robust canonicalization algorithm to ensure that topologically identical formulas (even if rotated or reflected) are recognized as the same, preventing duplicates in your catalog.
+
+Chirality Map: `validator.js` exposes `getChiralityForTile()` which converts a tile's connection pattern into a canonical bitstring. Known bitstrings are mapped to short labels like `A`, `AB`, or `ACE`. This aids in instantly spotting rotational or reflection duplicates during generation.
 
 Interactive Formula Builder:
 

--- a/script.js
+++ b/script.js
@@ -192,6 +192,15 @@ function recurseGenerate(currentConfig, availablePips, maxDepth) {
         const canonicalForm = getCanonicalForm(configCopy);
 
         if (!window.globalSeenConfigs.has(canonicalForm)) {
+            // Pretty-print instantly for easier eyeballing
+            const chiralityCode = configCopy
+                .map(t => getChiralityForTile(t, configCopy))
+                .join(":");
+            console.info(
+                `[Formula] ${configCopy.length} tiles | ${chiralityCode} | ` +
+                `${configCopy.map(t => t.pips).sort().join(":")} canonical=${canonicalForm}`
+            );
+
             const result = validateFormula(configCopy);
             formulasToClassify.push(new FormulaRecord(configCopy, result, "Pending Classification"));
             saveToLocalStorage(LS_KEY_GENERATED_TO_CLASSIFY, formulasToClassify);


### PR DESCRIPTION
## Summary
- add `getChiralityForTile()` helper to compute canonical chirality bitstrings
- expose new chirality helper globally and update chirality mappings
- log newly discovered formulas with chirality codes
- document chirality map usage in README

## Testing
- `node --version`
- `node -e 'global.window={};require("./validator.js");const config=[{id:1,q:0,r:0,pips:1,connections:[{targetId:2}]},{id:2,q:1,r:0,pips:1,connections:[{targetId:1}]}];console.log(window.getChiralityForTile(config[0],config));'`
- `node -e 'global.window={};require("./validator.js");const config=[{id:1,q:0,r:0,pips:2,connections:[{targetId:2},{targetId:3}]},{id:2,q:1,r:0,pips:1,connections:[{targetId:1}]},{id:3,q:0,r:1,pips:1,connections:[{targetId:1}]}];console.log(window.getChiralityForTile(config[0],config));'`


------
https://chatgpt.com/codex/tasks/task_e_687c2213618483329d13c1f0524826d4